### PR TITLE
Added support for a yotta_plugins folder containing command modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 git-access-testing
 github-access-testing
 *~
+yt

--- a/yotta/main.py
+++ b/yotta/main.py
@@ -199,7 +199,8 @@ def main():
     addParser('config', 'config', 'Display the target configuration info.')
     addParser('shrinkwrap', 'shrinkwrap', 'Create a yotta-shrinkwrap.json file to freeze dependency versions.')
 
-    # check for plugins in *cwd*/yotta_plugins
+
+    # check for plugins in ./yotta_plugins
     # if found, import them and add parsers accordingly
     searchdir = os.getcwd() + '/yotta_plugins'
     if os.path.exists(searchdir):
@@ -208,8 +209,19 @@ def main():
             for file in files:
                 if file.endswith(".py") and file != '__init__.py':
                     import importlib
-                    mod = importlib.import_module('yotta_plugins.' + os.path.splitext(os.path.basename(file))[0])
-                    addParser(mod.name, os.path.splitext(os.path.basename(file))[0], mod.description, mod.help)
+                    try:
+                        mod = importlib.import_module('yotta_plugins.' + os.path.splitext(os.path.basename(file))[0])
+                        try:
+                            addParser(mod.name, os.path.splitext(os.path.basename(file))[0], mod.description, mod.help)
+                        except AttributeError:
+                            continue;
+                    except ImportError:
+                        if not os.path.exists(searchdir + '/__init__.py'):
+                            logging.error('\"./yotta_plugins/\" does not contain \"__init__.py\"')
+                            sys.exit(-1)
+                        else:
+                            logging.error("Unknown plugin import error.")
+                            sys.exit(-1)                  
 
     # short synonyms, subparser.choices is a dictionary, so use update() to
     # merge in the keys from another dictionary

--- a/yt
+++ b/yt
@@ -1,0 +1,5 @@
+#! /usr/bin/env python
+
+import yotta
+yotta.main()
+

--- a/yt
+++ b/yt
@@ -1,5 +1,0 @@
-#! /usr/bin/env python
-
-import yotta
-yotta.main()
-


### PR DESCRIPTION
Also moved a copy of yt out to the root yotta directory to allow execution from within the cloned repository folder (temporary and unnecessary for deployment)
@karlj please review.
